### PR TITLE
Loosen pulldown-cmark version constraint to >=0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ readme = "./README.md"
 rust-version = "1.58"
 
 [dependencies]
-pulldown-cmark = { version = "0.11.0", default-features = false }
+pulldown-cmark = { version = ">=0.11", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.152", features = ["derive"] }
 toml = "0.8.0"
-pulldown-cmark = { version = "0.11.0", default-features = false, features = [
+pulldown-cmark = { version = ">=0.11", default-features = false, features = [
     "html",
 ] }
 


### PR DESCRIPTION
Allows compatibility with both `pulldown-cmark` v0.11 and v0.12, enabling projects to use newer versions without breaking changes.