### PR TITLE
Update to pulldown-cmark 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ readme = "./README.md"
 rust-version = "1.58"
 
 [dependencies]
-pulldown-cmark = { version = "0.11.0", default-features = false }
+pulldown-cmark = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.152", features = ["derive"] }
 toml = "0.8.0"
-pulldown-cmark = { version = "0.11.0", default-features = false, features = [
+pulldown-cmark = { version = "0.12", default-features = false, features = [
     "html",
 ] }
 


### PR DESCRIPTION
Allows the crate to be used with newer `pulldown-cmark` version **0.12**.