### PR TITLE
Update dependencies and increment version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ readme = "./README.md"
 rust-version = "1.58"
 
 [dependencies]
-pulldown-cmark = { version = "0.12", default-features = false }
+pulldown-cmark = { version = "0.13", default-features = false }
 
 [dev-dependencies]
-serde = { version = "1.0.152", features = ["derive"] }
-toml = "0.8.0"
-pulldown-cmark = { version = "0.12", default-features = false, features = [
+serde = { version = "1.0.219", features = ["derive"] }
+toml = "0.9"
+pulldown-cmark = { version = "0.13", default-features = false, features = [
     "html",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulldown-cmark-frontmatter"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Frontmatter extractor for Markdown documents"


### PR DESCRIPTION
Just the title.

Current version is incompatible with the latest version of `pulldown-cmark` (v0.13).